### PR TITLE
Display IP after proxy connection

### DIFF
--- a/main.js
+++ b/main.js
@@ -330,6 +330,14 @@ async function mainMenu(provider, wallet) {
     console.log(`Using proxy: ${selectedProxy}`);
     const agent = new HttpsProxyAgent(selectedProxy);
     axiosInstance = axios.create({ httpAgent: agent, httpsAgent: agent });
+    try {
+      const ipRes = await axiosInstance.get('https://api.ipify.org?format=json', { timeout: 5000 });
+      if (ipRes?.data?.ip) {
+        console.log(`Connected to the IP: ${ipRes.data.ip}`);
+      }
+    } catch (err) {
+      console.warn(`Could not determine proxy IP: ${err.message}`);
+    }
   } else {
     axiosInstance = axios.create();
   }


### PR DESCRIPTION
## Summary
- after connecting to a proxy, fetch the public IP
- log the connected IP so users know which proxy is used

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68667ad077b483239c606df4646cf931