### PR TITLE
Implement random delay between transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A command-line tool for batch token swaps on the Pharos testnet using the DODO r
 * ✅ Interactive CLI for swapping PHRS to other tokens (e.g. WETH, WBTC, USDC, USDT)
 * ↔ Swap PHRS directly to WPHRS
 * 🔁 Supports batch swaps with user-defined repeat count
+* ⏲ Adds a random delay (40-120s) between transactions
 * 🔄 Retries failed swaps automatically
 * ⏱ Timeout protection using `AbortController`
 * 🌐 Fetches real-time DODO routes with slippage control

--- a/main.js
+++ b/main.js
@@ -26,6 +26,14 @@ const PHAROS_RPC_URLS = [
 
 let axiosInstance = axios.create();
 
+// Delay between consecutive transactions in milliseconds
+const MIN_TX_DELAY_MS = 40 * 1000; // 40 seconds
+const MAX_TX_DELAY_MS = 120 * 1000; // 120 seconds
+
+function randomTxDelay() {
+  return Math.floor(Math.random() * (MAX_TX_DELAY_MS - MIN_TX_DELAY_MS + 1)) + MIN_TX_DELAY_MS;
+}
+
 function readProxiesFromFile(filename) {
   try {
     const content = fs.readFileSync(filename, 'utf8');
@@ -139,7 +147,7 @@ async function batchSwap(wallet, from, to, value, count) {
     } catch (e) {
       console.error(`❌ Swap #${i + 1} failed:`, e.message);
     }
-    await new Promise(r => setTimeout(r, 1000)); // wait 1s between swaps
+    await new Promise(r => setTimeout(r, randomTxDelay()));
   }
 }
 
@@ -165,7 +173,7 @@ async function batchSendNative(wallet, recipients, amountWei, count) {
     } catch (e) {
       console.error(`❌ Send #${i + 1} failed:`, e.message);
     }
-    await new Promise(r => setTimeout(r, 1000));
+    await new Promise(r => setTimeout(r, randomTxDelay()));
   }
 }
 


### PR DESCRIPTION
## Summary
- add config for minimum and maximum transaction delay
- delay swaps and sends for a random interval (40-120s)
- document delay feature in the README

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_b_6866872d9f4c8323bcaf6bf04019fdc6