### PR TITLE
Add AutoSwap option and token selection menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ A command-line tool for batch token swaps on the Pharos testnet using the DODO r
 * ↔ Swap PHRS directly to WPHRS
 * 🔁 Supports batch swaps with user-defined repeat count
 * ⏲ Adds a random delay (40-120s) between transactions
+* 🎲 Random amount ranges for swaps and sends via `.env`
 * 🔄 Retries failed swaps automatically
 * ⏱ Timeout protection using `AbortController`
+* ⚡ Auto-swap or send using random amounts via the menu
 * 🌐 Fetches real-time DODO routes with slippage control
 * 🔐 Uses `.env` file to load one or more private keys securely
 * 🚪 Interactive menu with a quit option
@@ -43,6 +45,9 @@ Create your `.env` like this (use `PRIVATE_KEY1`, `PRIVATE_KEY2`, etc.):
 ```
 PRIVATE_KEY1=0xyourfirstprivatekey
 PRIVATE_KEY2=0xyoursecondprivatekey
+# Optional: set min and max random amounts (in PHRS)
+AMOUNT_SWAP=0.1,0.9
+AMOUNT_SEND=0.1,0.9
 ```
 
 ---
@@ -68,8 +73,8 @@ On Pharos testnet:
 npm start
 ```
 
-Use the interactive menu to select **Swap Tokens** and provide the token symbol, amount, and number of repeats when prompted.
-The menu also includes **Swap PHRS/WPHRS**, **Swap Tokens to PHRS**, and **Send PHRS** using the addresses in `wallets.txt`.
+Use the interactive menu to select **Swap Tokens** or **Swap Tokens to PHRS** using a token list. You can also choose **AutoSwap (random amounts)** to automatically swap or send with amounts randomized from your `.env` ranges.
+The menu also includes **Swap PHRS/WPHRS** and **Send PHRS**, plus the new **AutoSwap (random amounts)** option.
 
 ---
 


### PR DESCRIPTION
## Summary
- add TOKEN_CHOICES list and new `autoMenu` to automate random swaps/sends
- extend main menu with AutoSwap option
- use list prompts for token selection instead of free text
- update README for new feature and usage instructions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68669698b7a883238bda9f543dd0b29a