### PR TITLE
Fix syntax error in main.js prompt

### DIFF
--- a/main.js
+++ b/main.js
@@ -330,9 +330,7 @@ async function mainMenu(provider, wallet) {
           name: "count",
           message: "🔁 How many swaps to perform?"
         }
-      ]);
-        }
-      );
+        ]);
 
       try {
         if (!answers.amount || isNaN(answers.amount)) throw new Error('Invalid amount');


### PR DESCRIPTION
## Summary
- remove stray closing bracket and parentheses from prompt

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_b_68669e0a62908323979483c5ae0fd72c